### PR TITLE
Includes florencenet support and kepler.resolve

### DIFF
--- a/dapp/package-lock.json
+++ b/dapp/package-lock.json
@@ -13,11 +13,9 @@
         "@taquito/tzip16": "^8.1.0",
         "@taquito/utils": "^8.1.0",
         "crypto-browserify": "^3.12.0",
-        "didkit-loader": "^0.1.2",
-        "didkit-wasm": "file:../../didkit/lib/web/loader/wasm",
         "events": "^3.3.0",
         "https-browserify": "^1.0.0",
-        "kepler-sdk": "^0.1.0",
+        "kepler-sdk": "^0.2.0",
         "os-browserify": "^0.3.0",
         "path-browserify": "^1.0.1",
         "stream-browserify": "^3.0.0",
@@ -63,6 +61,7 @@
     "../../didkit/lib/web/loader/wasm": {
       "name": "didkit-wasm-loader",
       "version": "0.1.0",
+      "extraneous": true,
       "devDependencies": {
         "eslint": "^7.22.0",
         "eslint-config-prettier": "^7.2.0",
@@ -3085,15 +3084,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/didkit-loader": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/didkit-loader/-/didkit-loader-0.1.3.tgz",
-      "integrity": "sha512-6+870PcYpo99RwZHj67Y69V6OFXfko6AoMSXKu3r9k+IQrRJTzocKzb03iho5IWYh7ChzlUVbHvxcjCDbi1Eug=="
-    },
-    "node_modules/didkit-wasm": {
-      "resolved": "../../didkit/lib/web/loader/wasm",
-      "link": true
-    },
     "node_modules/didyoumean": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.1.tgz",
@@ -5404,9 +5394,9 @@
       }
     },
     "node_modules/kepler-sdk": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/kepler-sdk/-/kepler-sdk-0.1.0.tgz",
-      "integrity": "sha512-if5Z5KCq7xjf2HRM0uVFHoTC1hW78ItLeUJXICVZ95b40iycjStvsZ/zIndisStUWLcciC5y4o55UbMOTJDBFw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/kepler-sdk/-/kepler-sdk-0.2.0.tgz",
+      "integrity": "sha512-6FDE4w0dhJ8AHfYzVXgYyvvsZbG8kF+56aJSpzPk6/4ObJcMupZGOcjCkAeN7DAYEUdIELN8ZxlFbMTiMFF7rQ==",
       "dependencies": {
         "@airgap/beacon-sdk": "^2.2.3",
         "cids": "^1.1.6",
@@ -16909,27 +16899,6 @@
         "minimist": "^1.1.1"
       }
     },
-    "didkit-loader": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/didkit-loader/-/didkit-loader-0.1.3.tgz",
-      "integrity": "sha512-6+870PcYpo99RwZHj67Y69V6OFXfko6AoMSXKu3r9k+IQrRJTzocKzb03iho5IWYh7ChzlUVbHvxcjCDbi1Eug=="
-    },
-    "didkit-wasm": {
-      "version": "file:../../didkit/lib/web/loader/wasm",
-      "requires": {
-        "eslint": "^7.22.0",
-        "eslint-config-prettier": "^7.2.0",
-        "eslint-config-standard": "^16.0.2",
-        "eslint-plugin-import": "^2.22.1",
-        "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-prettier": "^3.3.1",
-        "eslint-plugin-promise": "^4.3.1",
-        "local-web-server": "^4.2.1",
-        "prettier": "2.2.1",
-        "webpack": "^5.26.2",
-        "webpack-cli": "^4.5.0"
-      }
-    },
     "didyoumean": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.1.tgz",
@@ -18760,9 +18729,9 @@
       }
     },
     "kepler-sdk": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/kepler-sdk/-/kepler-sdk-0.1.0.tgz",
-      "integrity": "sha512-if5Z5KCq7xjf2HRM0uVFHoTC1hW78ItLeUJXICVZ95b40iycjStvsZ/zIndisStUWLcciC5y4o55UbMOTJDBFw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/kepler-sdk/-/kepler-sdk-0.2.0.tgz",
+      "integrity": "sha512-6FDE4w0dhJ8AHfYzVXgYyvvsZbG8kF+56aJSpzPk6/4ObJcMupZGOcjCkAeN7DAYEUdIELN8ZxlFbMTiMFF7rQ==",
       "requires": {
         "@airgap/beacon-sdk": "^2.2.3",
         "cids": "^1.1.6",

--- a/dapp/package.json
+++ b/dapp/package.json
@@ -41,7 +41,7 @@
     "crypto-browserify": "^3.12.0",
     "events": "^3.3.0",
     "https-browserify": "^1.0.0",
-    "kepler-sdk": "^0.1.0",
+    "kepler-sdk": "^0.2.0",
     "os-browserify": "^0.3.0",
     "path-browserify": "^1.0.1",
     "stream-browserify": "^3.0.0",

--- a/dapp/src/components/page/home/MyCredentials.svelte
+++ b/dapp/src/components/page/home/MyCredentials.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { IconLink, DownloadIcon } from 'components';
-  import { claimsStream, loadingContracts } from 'src/store';
+  import { claimsStream, loadingContracts, localKepler } from 'src/store';
 
   const makeDownloadable = (obj: object): string => {
     let stringify = JSON.stringify(obj, null, 2);
@@ -27,7 +27,10 @@
               .filter((claim) => claim.url)
               .map(async (claim) => {
                 let { url } = claim;
-                let jsonRes = await fetch(url);
+
+                // Set auth to false to not prompt the user for 3 signings in a row
+                // That hits the Beacon Wallet rate limit
+                let jsonRes = await localKepler.resolve(url, false); 
 
                 if (!jsonRes.ok || jsonRes.status !== 200) {
                   throw new Error(`Error in claims retrieval: ${jsonRes.statusText}`);

--- a/dapp/src/enums/NetworkType.ts
+++ b/dapp/src/enums/NetworkType.ts
@@ -2,6 +2,7 @@ enum NetworkType {
   MAINNET = 'mainnet',
   DELPHINET = 'delphinet',
   EDONET = 'edonet',
+  FLORENCENET = 'florencenet',
   CUSTOM = 'custom',
 }
 

--- a/dapp/src/routes/Home.svelte
+++ b/dapp/src/routes/Home.svelte
@@ -56,6 +56,7 @@
           <Option value="mainnet" text="mainnet" selected />
           <Option value="delphinet" text="delphinet" />
           <Option value="edonet" text="edonet" />
+          <Option value="florencenet" text="florencenet" />
           <Option value="custom" text="custom" />
         </Select>
       </p>


### PR DESCRIPTION
Adds florencenet to the `dapp` UI and resolves some rough edges transitioning to `kepler-sdk` using the `kepler://` protocol prefix. All functionality has been tested short of origination.

Will advise to merge in as soon as origination has been tested.