### PR TITLE
updates to v0.3.0 of kepler-sdk

### DIFF
--- a/dapp/package.json
+++ b/dapp/package.json
@@ -41,7 +41,7 @@
     "crypto-browserify": "^3.12.0",
     "events": "^3.3.0",
     "https-browserify": "^1.0.0",
-    "kepler-sdk": "^0.2.0",
+    "kepler-sdk": "^0.3.0",
     "os-browserify": "^0.3.0",
     "path-browserify": "^1.0.1",
     "stream-browserify": "^3.0.0",

--- a/dapp/src/store.ts
+++ b/dapp/src/store.ts
@@ -9,18 +9,15 @@ import * as contractLib from 'tzprofiles';
 
 import { PersonOutlined, TwitterIcon } from 'components';
 import SvelteComponentDev from '*.svelte';
-// TODO fix export in kepler :facepalm:
 import { Kepler, authenticator } from 'kepler-sdk';
 import { loadDIDKit } from './loader/didkit-loader';
 import ProfileDisplay from 'enums/ProfileDisplay';
 
 export const saveToKepler = async (...obj) => {
-  const dummyOrbit = 'uAYAEHiB_A0nLzANfXNkW5WCju51Td_INJ6UacFK7qY6zejzKoA';
   if (localKepler) {
     try {
-      const [first, ...rest] = obj;
       const addresses = await localKepler
-        .put(dummyOrbit, first, ...rest)
+        .createOrbit(...obj)
         .then((r) => r.text());
       alert.set({
         message: 'Successfuly uploaded to Kepler',
@@ -29,7 +26,6 @@ export const saveToKepler = async (...obj) => {
 
       return addresses
         .split('\n')
-        .map((address) => `kepler://v0:${dummyOrbit}/${address}`);
     } catch (e) {
       alert.set({
         message: e.message || JSON.stringify(e),
@@ -455,9 +451,7 @@ export const initWallet: () => Promise<void> = async () => {
     await newWallet.requestPermissions(requestPermissionsInput);
     localKepler = new Kepler(
       keplerInstance,
-      // NOTE: Ran into a typing err w/o any
-      // Consider correcting?
-      await authenticator<any>(newWallet.client)
+      await authenticator(newWallet.client, 'TZProfiles')
     );
     const Tezos = new TezosToolkit(urlNode);
     Tezos.addExtension(new Tzip16Module());


### PR DESCRIPTION
- removes the need for `<any>` generic on `authenticator`
- returns the `kepler://` URI from Kepler operations instead of the raw CID (since [Kepler PR #16](https://github.com/spruceid/kepler/pull/19)). this has a requirement on deploying the latest Kepler version