### PR TITLE
Updates worker to include Instagram authentication and post signature…

### DIFF
--- a/worker/Cargo.lock
+++ b/worker/Cargo.lock
@@ -270,7 +270,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 dependencies = [
- "sha2",
+ "sha2 0.9.5",
 ]
 
 [[package]]
@@ -598,7 +598,7 @@ dependencies = [
  "ed25519",
  "rand 0.7.3",
  "serde",
- "sha2",
+ "sha2 0.9.5",
  "zeroize",
 ]
 
@@ -1075,7 +1075,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "ecdsa",
  "elliptic-curve",
- "sha2",
+ "sha2 0.9.5",
  "sha3",
 ]
 
@@ -1317,7 +1317,7 @@ checksum = "2f05f5287453297c4c16af5e2b04df8fd2a3008d70f252729650bc6d7ace5844"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
- "sha2",
+ "sha2 0.9.5",
 ]
 
 [[package]]
@@ -1737,6 +1737,18 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
+dependencies = [
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
+ "fake-simd",
+ "opaque-debug 0.2.3",
+]
+
+[[package]]
+name = "sha2"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
@@ -1814,6 +1826,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sshkeys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c69bf9da628c9a435416cc06f64445c8fa467efe52100bec0912c820ac80fc8"
+dependencies = [
+ "base64 0.12.3",
+ "byteorder",
+ "sha2 0.8.2",
+]
+
+[[package]]
 name = "ssi"
 version = "0.2.2"
 dependencies = [
@@ -1850,8 +1873,9 @@ dependencies = [
  "serde_jcs",
  "serde_json",
  "serde_urlencoded",
- "sha2",
+ "sha2 0.9.5",
  "simple_asn1",
+ "sshkeys",
  "ssi-contexts",
  "thiserror",
 ]

--- a/worker/src/instagram.rs
+++ b/worker/src/instagram.rs
@@ -1,0 +1,136 @@
+use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct User {
+    pub username: String,
+    pub id: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Post {
+    pub sig: String,
+    pub sig_target: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CaptionWrapper {
+    pub caption: String,
+    pub permalink: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PostWrapper {
+    pub data: Vec<PostId>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PostId {
+    pub id: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Auth {
+    pub client_id: String,
+    pub client_secret: String,
+    pub redirect_uri: String,
+    pub code: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct AuthForm {
+    pub client_id: String,
+    pub client_secret: String,
+    pub grant_type: String,
+    pub redirect_uri: String,
+    pub code: String,
+}
+
+impl AuthForm {
+    fn from_auth(auth: Auth) -> Self {
+        AuthForm {
+            client_id: auth.client_id,
+            client_secret: auth.client_secret,
+            grant_type: "authorization_code".into(),
+            redirect_uri: auth.redirect_uri,
+            code: auth.code,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct TokenTrade {
+    pub access_token: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct KVInner {
+    pub sig: String,
+    pub link: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct KVWrapper {
+    pub key: String,
+    pub val: KVInner,
+}
+
+pub fn target_from_handle(handle: &str, pkh: &str) -> String {
+    return format!("I am attesting that this Instagram handle @{} is linked to the Tezos account {} for @tezos_profiles\n\n", handle, pkh);
+}
+
+pub async fn retrieve_user(access_token: &str) -> Result<User> {
+    let url = format!(
+        "https://graph.instagram.com/me?fields=id,username&access_token={}",
+        access_token
+    );
+
+    let client = reqwest::Client::new();
+    let res: User = client.get(Url::parse(&url)?).send().await?.json().await?;
+
+    Ok(res)
+}
+
+pub async fn retrieve_post(user: &User, access_token: &str) -> Result<(String, String)> {
+    let url = format!(
+        "https://graph.instagram.com/v11.0/{}/media?access_token={}",
+        &user.id, access_token
+    );
+
+    let client = reqwest::Client::new();
+    let res: PostWrapper = client.get(Url::parse(&url)?).send().await?.json().await?;
+
+    let search = res.data.iter();
+
+    for data in search {
+        let url = format!(
+            "https://graph.instagram.com/{}?fields=caption,permalink&access_token={}",
+            data.id, access_token
+        );
+
+        let post: CaptionWrapper = client.get(Url::parse(&url)?).send().await?.json().await?;
+
+        for line in post.caption.split('\n').collect::<Vec<&str>>() {
+            if line.starts_with("sig:") {
+                return Ok((line[4..].to_string(), post.permalink));
+            }
+        }
+    }
+
+    Err(anyhow!("No post with signature found in recent posts"))
+}
+
+pub async fn trade_code_for_token(auth: Auth) -> Result<String> {
+    let url = "https://api.instagram.com/oauth/access_token";
+    let client = reqwest::Client::new();
+    let res: TokenTrade = client
+        .post(Url::parse(&url)?)
+        .form(&AuthForm::from_auth(auth))
+        .send()
+        .await?
+        .json()
+        .await?;
+
+    Ok(res.access_token)
+}

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -3,6 +3,7 @@ extern crate wasm_bindgen;
 #[macro_use]
 extern crate log;
 
+mod instagram;
 mod twitter;
 mod utils;
 
@@ -41,7 +42,40 @@ static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
 const SPRUCE_DIDWEB: &str = "did:web:tzprofiles.com";
 
-fn build_vc_(pk: &JWK, twitter_handle: &str) -> Result<Credential> {
+fn build_instagram_vc_(pk: &JWK, instagram_handle: &str) -> Result<Credential> {
+    Ok(serde_json::from_value(json!({
+      "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          {
+              "sameAs": "http://schema.org/sameAs",
+              "InstagramVerification": "https://tzprofiles.com/InstagramVerification",
+              "InstagramVerificationPublicPost": {
+                  "@id": "https://tzprofiles.com/InstagramVerificationPublicPost",
+                  "@context": {
+                      "@version": 1.1,
+                      "@protected": true,
+                      "handle": "https://tzprofiles.com/handle",
+                      "timestamp": {
+                          "@id": "https://tzprofiles.com/timestamp",
+                          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+                      },
+                      "postUrl": "https://tzprofiles.com/postUrl"
+                  }
+              }
+          }
+      ],
+      "issuanceDate": Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true),
+      "id": format!("urn:uuid:{}", Uuid::new_v4().to_string()),
+      "type": ["VerifiableCredential", "InstagramVerification"],
+      "credentialSubject": {
+          "id": format!("did:pkh:tz:{}", &hash_public_key(pk)?),
+          "sameAs": "https://instagram.com/".to_string() + instagram_handle
+      },
+      "issuer": SPRUCE_DIDWEB
+    }))?)
+}
+
+fn build_twitter_vc_(pk: &JWK, twitter_handle: &str) -> Result<Credential> {
     // Credential {
     //     context: Contexts::Object(vec![Context::URI(URI::String("https://www.w3.org/2018/credentials/v1".to_string())), Context::URI(URI::String("https://schema.org/".to_string())), Context::Object()])
     // }
@@ -85,6 +119,90 @@ fn verify_signature(data: &str, pk: &JWK, sig: &str) -> Result<()> {
 }
 
 #[wasm_bindgen]
+pub async fn handle_instagram_login(
+    client_id: String,
+    client_secret: String,
+    redirect_uri: String,
+    code: String,
+) -> Promise {
+    future_to_promise(async move {
+        let auth = instagram::Auth {
+            client_id,
+            client_secret,
+            redirect_uri,
+            code,
+        };
+
+        let access_token: String = jserr!(instagram::trade_code_for_token(auth).await);
+        let user = jserr!(instagram::retrieve_user(&access_token).await);
+        let (sig, permalink) = jserr!(instagram::retrieve_post(&user, &access_token).await);
+
+        Ok(jserr!(serde_json::to_string(&instagram::KVWrapper {
+            key: user.username,
+            val: instagram::KVInner {
+                sig: sig,
+                link: permalink,
+            },
+        }))
+        .into())
+    })
+}
+
+#[wasm_bindgen]
+pub async fn witness_instagram_post(
+    secret_key_jwk: String,
+    public_key_tezos: String,
+    ig_handle: String,
+    ig_link: String,
+    sig: String,
+) -> Promise {
+    future_to_promise(async move {
+        let pk: JWK = jserr!(jwk_from_tezos_key(&public_key_tezos));
+        let sk: JWK = jserr!(serde_json::from_str(&secret_key_jwk));
+
+        let mut vc = jserr!(build_instagram_vc_(&pk, &ig_handle));
+        let sig_target = instagram::target_from_handle(&ig_handle, jserr!(&hash_public_key(&pk)));
+
+        let mut props = HashMap::new();
+        props.insert(
+            "publicKeyJwk".to_string(),
+            jserr!(serde_json::to_value(pk.clone())),
+        );
+        jserr!(verify_signature(&sig_target, &pk, &sig));
+
+        info!("Issue credential.");
+        let mut evidence_map = HashMap::new();
+        evidence_map.insert("handle".to_string(), serde_json::Value::String(ig_handle));
+        evidence_map.insert(
+            "timestamp".to_string(),
+            serde_json::Value::String(Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)),
+        );
+        evidence_map.insert("postUrl".to_string(), serde_json::Value::String(ig_link));
+
+        let evidence = Evidence {
+            id: None,
+            type_: vec!["InstagramVerificationPublicPost".to_string()],
+            property_set: Some(evidence_map),
+        };
+        vc.evidence = Some(OneOrMany::One(evidence));
+
+        let proof = jserr!(
+            vc.generate_proof(
+                &sk,
+                &LinkedDataProofOptions {
+                    verification_method: Some(format!("{}#controller", SPRUCE_DIDWEB)),
+                    ..Default::default()
+                }
+            )
+            .await
+        );
+        vc.proof = Some(OneOrMany::One(proof));
+
+        Ok(jserr!(serde_json::to_string(&vc)).into())
+    })
+}
+
+#[wasm_bindgen]
 pub async fn witness_tweet(
     secret_key_jwk: String,
     public_key_tezos: String,
@@ -98,7 +216,7 @@ pub async fn witness_tweet(
         let pk: JWK = jserr!(jwk_from_tezos_key(&public_key_tezos));
         let sk: JWK = jserr!(serde_json::from_str(&secret_key_jwk));
         let twitter_res = jserr!(twitter::retrieve_tweet(twitter_token, tweet_id.clone()).await);
-        let mut vc = jserr!(build_vc_(&pk, &twitter_handle));
+        let mut vc = jserr!(build_twitter_vc_(&pk, &twitter_handle));
 
         if twitter_handle.to_lowercase() != twitter_res.includes.users[0].username.to_lowercase() {
             jserr!(Err(anyhow!(format!(
@@ -110,6 +228,7 @@ pub async fn witness_tweet(
 
         let (sig_target, sig) =
             jserr!(twitter::extract_signature(twitter_res.data[0].text.clone()));
+
         let mut props = HashMap::new();
         props.insert(
             "publicKeyJwk".to_string(),

--- a/worker/src/utils.rs
+++ b/worker/src/utils.rs
@@ -1,2 +1,19 @@
 extern crate console_error_panic_hook;
+use anyhow::{anyhow, Result};
+
 pub use self::console_error_panic_hook::set_once as set_panic_hook;
+
+pub fn extract_signature(text: String) -> Result<(String, String)> {
+    let mut sig_target = "".to_string();
+    for line in text.split('\n').collect::<Vec<&str>>() {
+        if line.starts_with("sig:") {
+            if sig_target != "" {
+                return Ok((sig_target, line[4..].to_string().clone()));
+            } else {
+                return Err(anyhow!("Signature target is empty."));
+            }
+        }
+        sig_target = format!("{}{}\n", sig_target, line);
+    }
+    Err(anyhow!("Signature not found in tweet."))
+}

--- a/worker/wrangler.toml.example
+++ b/worker/wrangler.toml.example
@@ -4,3 +4,6 @@ account_id = ""
 workers_dev = true
 route = ""
 zone_id = ""
+kv_namespaces = [
+    { binding = "INSTAGRAM_CLAIM", preview_id = "", id = "" }
+]


### PR DESCRIPTION
… validation

This adds two routes to the worker, the first is the auth call back of the Instagram login process the second is the post-retrieval process.

The flow is that the user
Creates the signature ->
Posts media with the signature as the caption ->
Authorizes with Instagram from TZP to a new tab -> 
Copies a token from the Worker -> 
Pastes it into TZP, which passes it back to the worker, along with the provided handle and Tezos PKH ->
Worker looks up the Post, validates the signature, returns it to TZP

This code is just to update the worker. It assumes that `IG_APP_SECRET`, `IG_APP_ID` and `IG_APP_REDIRECT` are set as secrets. This has already been done, but `IG_APP_REDIRECT` 

Once the worker has been published we can update `IG_APP_REDIRECT` to be `https://tzprofiles_witness.rebase-verifier.workers.dev/instagram_login` along with the link that we've approved with the IG back-end. Then it'll be significantly easier to test than the present (where I'm using a ngrok link that changes every 2 hours).