### PR TITLE
Bug fix - URL Format

### DIFF
--- a/dapp/src/components/page/view/PublicProfileView.svelte
+++ b/dapp/src/components/page/view/PublicProfileView.svelte
@@ -18,7 +18,7 @@
   const params = useParams();
 
   const formatWebsite = (url: string): string => {
-    if (url.startsWith('https://' || 'www.')) {
+    if (url.startsWith('https://' || 'www.' || 'http://')) {
       return url;
     }
     return 'http://' + url;

--- a/dapp/src/components/page/view/PublicProfileView.svelte
+++ b/dapp/src/components/page/view/PublicProfileView.svelte
@@ -17,6 +17,13 @@
 
   const params = useParams();
 
+  const formatWebsite = (url: string): string => {
+    if (url.startsWith('https://' || 'www.')) {
+      return url;
+    }
+    return 'http://' + url;
+  };
+
   let isCredentialSourceDropdownOpen = false;
   $: shouldDisplayOriginalImage = true;
 </script>
@@ -56,7 +63,7 @@
 
   {#if basicClaim}
     <!-- Specially treat basicClaim -->
-    <a href={basicDraft.website || ''} target="_blank">
+    <a href={formatWebsite(basicDraft.website)} target="_blank">
       <div class="my-6">{basicDraft.website || ''}</div>
     </a>
     <div class="break-normal description-section">


### PR DESCRIPTION
**Summary**

- Previously, website URL's that don't begin with http or www could not be rendered (see such profile: http://localhost:9080/view/tz1SJEeZviPzRSzHtZtPJwndZNk61PvdFfJD) . A link formatter has been added to fix that. 