### PR TITLE
updates worker to allow CF instagram claim build to work

### DIFF
--- a/worker/src/instagram.rs
+++ b/worker/src/instagram.rs
@@ -81,10 +81,6 @@ pub struct KVWrapper {
     pub val: KVInner,
 }
 
-pub fn target_from_handle(handle: &str, pkh: &str) -> String {
-    return format!("I am attesting that this Instagram handle @{} is linked to the Tezos account {} for Tezos Profiles\n\n", handle, pkh);
-}
-
 pub async fn retrieve_user(access_token: &str) -> Result<User> {
     let url = format!(
         "https://graph.instagram.com/me?fields=id,username&access_token={}",

--- a/worker/src/utils.rs
+++ b/worker/src/utils.rs
@@ -1,4 +1,3 @@
 extern crate console_error_panic_hook;
-use anyhow::{anyhow, Result};
 
 pub use self::console_error_panic_hook::set_once as set_panic_hook;

--- a/worker/worker/worker.js
+++ b/worker/worker/worker.js
@@ -229,7 +229,8 @@ async function handler_witness_instagram_post(request) {
   try {
     const { searchParams } = new URL(request.url);
 
-    let pk = decodeURI(searchParams.get("pk"));
+    let pk = decodeURIComponent(searchParams.get("pk"));
+    let sig_target = decodeURIComponent(searchParams.get("sig_target"));
     let handle = searchParams.get("handle");
     let sig_type = searchParams.get("sig_type");
 
@@ -246,7 +247,15 @@ async function handler_witness_instagram_post(request) {
     const { witness_instagram_post } = wasm_bindgen;
     await wasm_bindgen(wasm);
 
-    const vc = await witness_instagram_post(TZPROFILES_ME_PRIVATE_KEY, pk, handle, kvObj.link, kvObj.sig, sig_type);
+    const vc = await witness_instagram_post(
+      TZPROFILES_ME_PRIVATE_KEY,
+      pk,
+      handle,
+      kvObj.link,
+      kvObj.sig,
+      sig_target,
+      sig_type,
+    );
 
     return new Response(vc, { status: 200, headers: headers });
   } catch (error) {
@@ -274,7 +283,7 @@ async function handler_instagram_login(request) {
     const res = `<html>
     <body>
       <p>Instagram claim has been prepared.</p> 
-      <p>Please return to Tezos Profiles to save it to your profile!</p> 
+      <p>Please return to the previous window to save it to your profile!</p> 
     </body>
 </html>`;
 


### PR DESCRIPTION
Updates the Worker's Instagram route to have more general completion text, adds the sig target allowing for different signatures in the future.