### PR TITLE
Fix: patch Twitter username length requirement

### DIFF
--- a/dapp/src/routes/Twitter.svelte
+++ b/dapp/src/routes/Twitter.svelte
@@ -94,7 +94,7 @@
               });
             }}
             class="ml-4 lg:ml-0"
-            disabled={twitterHandle.length < 4}
+            disabled={twitterHandle.length < 1}
             small
           />
         {/if}


### PR DESCRIPTION
This fixes the username length requirement on the Twitter verification flow (reduces required length from 4 to 1). Currently, Twitter requires at least 4 characters in a username, but previously this wasn't the case.

This enables legacy Twitter username owners to also complete the verification flow. 