### PR TITLE
Ghostnet support

### DIFF
--- a/dapp/package-lock.json
+++ b/dapp/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@metamask/detect-provider": "^1.2.0",
         "@spruceid/tzprofiles": "^1.0.1",
-        "@taquito/beacon-wallet": "^12.0.3",
+        "@taquito/beacon-wallet": "^13.0.1",
         "@taquito/local-forging": "^12.0.3",
         "@taquito/taquito": "^12.0.3",
         "@taquito/tzip16": "^12.0.3",
@@ -65,6 +65,43 @@
         "webpack-dev-server": "^4.3.1"
       }
     },
+    "node_modules/@airgap/beacon-core": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-core/-/beacon-core-3.1.3.tgz",
+      "integrity": "sha512-AU8VCS5DeK4aXLIeiW6ie377gwEXkuxDS+UiH60yID5VYGc4YgD+kTrjh0BawCJbQumj/+H5OphGl6n+XJX6Ww==",
+      "dependencies": {
+        "@airgap/beacon-types": "^3.1.3",
+        "@airgap/beacon-utils": "^3.1.2",
+        "@types/libsodium-wrappers": "0.7.9",
+        "bs58check": "2.1.2",
+        "libsodium-wrappers": "0.7.9"
+      }
+    },
+    "node_modules/@airgap/beacon-core/node_modules/@types/libsodium-wrappers": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/@types/libsodium-wrappers/-/libsodium-wrappers-0.7.9.tgz",
+      "integrity": "sha512-LisgKLlYQk19baQwjkBZZXdJL0KbeTpdEnrAfz5hQACbklCY0gVFnsKUyjfNWF1UQsCSjw93Sj5jSbiO8RPfdw=="
+    },
+    "node_modules/@airgap/beacon-core/node_modules/libsodium-wrappers": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.9.tgz",
+      "integrity": "sha512-9HaAeBGk1nKTRFRHkt7nzxqCvnkWTjn1pdjKgcUnZxj0FyOP4CnhgFhMdrFfgNsukijBGyBLpP2m2uKT1vuWhQ==",
+      "dependencies": {
+        "libsodium": "^0.7.0"
+      }
+    },
+    "node_modules/@airgap/beacon-dapp": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-dapp/-/beacon-dapp-3.1.3.tgz",
+      "integrity": "sha512-iyXZK9VTL/YRxY2JQDJSWT1+wHuVJ28+JL5ArmQRoOlhEUTVSBKdtSYX34ojOSsqQEGUuW9MTLIM/0vrWQYR3Q==",
+      "dependencies": {
+        "@airgap/beacon-core": "^3.1.3",
+        "@airgap/beacon-transport-matrix": "^3.1.3",
+        "@airgap/beacon-transport-postmessage": "^3.1.3",
+        "@airgap/beacon-ui": "^3.1.3",
+        "qrcode-generator": "1.4.4"
+      }
+    },
     "node_modules/@airgap/beacon-sdk": {
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/@airgap/beacon-sdk/-/beacon-sdk-2.3.9.tgz",
@@ -77,6 +114,100 @@
         "bs58check": "2.1.2",
         "libsodium-wrappers": "0.7.8",
         "qrcode-generator": "1.4.4"
+      }
+    },
+    "node_modules/@airgap/beacon-transport-matrix": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-transport-matrix/-/beacon-transport-matrix-3.1.3.tgz",
+      "integrity": "sha512-pbehQ4IfMU4lR5mkLTYU5QorrbMvxvOXiWisqziIG0XCAj7FwiZVx30ljT22vWiqygGSTrVGGTwUuhbqX6aKtA==",
+      "dependencies": {
+        "@airgap/beacon-core": "^3.1.3",
+        "@airgap/beacon-utils": "^3.1.2",
+        "axios": "0.24.0"
+      }
+    },
+    "node_modules/@airgap/beacon-transport-matrix/node_modules/axios": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.4"
+      }
+    },
+    "node_modules/@airgap/beacon-transport-postmessage": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-transport-postmessage/-/beacon-transport-postmessage-3.1.3.tgz",
+      "integrity": "sha512-Cv2Bjpvex5XZ1n9GVfi4iPA4l1hz8LcvBSec6iCEI0Ejjt8bYTPqJESZyxh5Z5A4VXG/gSSS2i1WhzzoyorbfA==",
+      "dependencies": {
+        "@airgap/beacon-core": "^3.1.3",
+        "@airgap/beacon-types": "^3.1.3",
+        "@airgap/beacon-utils": "^3.1.2",
+        "@types/libsodium-wrappers": "0.7.9",
+        "libsodium-wrappers": "0.7.9"
+      }
+    },
+    "node_modules/@airgap/beacon-transport-postmessage/node_modules/@types/libsodium-wrappers": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/@types/libsodium-wrappers/-/libsodium-wrappers-0.7.9.tgz",
+      "integrity": "sha512-LisgKLlYQk19baQwjkBZZXdJL0KbeTpdEnrAfz5hQACbklCY0gVFnsKUyjfNWF1UQsCSjw93Sj5jSbiO8RPfdw=="
+    },
+    "node_modules/@airgap/beacon-transport-postmessage/node_modules/libsodium-wrappers": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.9.tgz",
+      "integrity": "sha512-9HaAeBGk1nKTRFRHkt7nzxqCvnkWTjn1pdjKgcUnZxj0FyOP4CnhgFhMdrFfgNsukijBGyBLpP2m2uKT1vuWhQ==",
+      "dependencies": {
+        "libsodium": "^0.7.0"
+      }
+    },
+    "node_modules/@airgap/beacon-types": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-types/-/beacon-types-3.1.3.tgz",
+      "integrity": "sha512-UCsba/Dut6cUrYIe2bnLlCOGsCyQOD/A4gQGdCuviLfqomMQv5m/XoJTtl9jKOlOIm2ytvyl8Z/zrNhK7SZMmA==",
+      "dependencies": {
+        "@types/chrome": "0.0.163"
+      }
+    },
+    "node_modules/@airgap/beacon-types/node_modules/@types/chrome": {
+      "version": "0.0.163",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.163.tgz",
+      "integrity": "sha512-g+3E2tg/ukFsEgH+tB3a/b+J1VSvq/8gh2Jwih9eq+T3Idrz7ngj97u+/ya58Bfei2TQtPlRivj1FsCaSnukDA==",
+      "dependencies": {
+        "@types/filesystem": "*",
+        "@types/har-format": "*"
+      }
+    },
+    "node_modules/@airgap/beacon-ui": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-ui/-/beacon-ui-3.1.3.tgz",
+      "integrity": "sha512-H6L9lynsn/JsjrKEBrN5lYr1S/d8l3aY48lciNfxJALOR1mOjVBn+tepKP/tVZPansvvf27/8yKwUTMVnp4Qwg==",
+      "dependencies": {
+        "@airgap/beacon-core": "^3.1.3",
+        "@airgap/beacon-transport-postmessage": "^3.1.3",
+        "@airgap/beacon-types": "^3.1.3",
+        "@airgap/beacon-utils": "^3.1.2"
+      }
+    },
+    "node_modules/@airgap/beacon-utils": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-utils/-/beacon-utils-3.1.2.tgz",
+      "integrity": "sha512-kaDFDSes54Zn/cc6Pvk9BfrrvrLwqTPNuEg15uzAQkDRsZ8e/t7SZ7KTNytw2OJPI0qG792zvd5uJwSG8a0Jdg==",
+      "dependencies": {
+        "@types/libsodium-wrappers": "0.7.9",
+        "bs58check": "2.1.2",
+        "libsodium-wrappers": "0.7.9"
+      }
+    },
+    "node_modules/@airgap/beacon-utils/node_modules/@types/libsodium-wrappers": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/@types/libsodium-wrappers/-/libsodium-wrappers-0.7.9.tgz",
+      "integrity": "sha512-LisgKLlYQk19baQwjkBZZXdJL0KbeTpdEnrAfz5hQACbklCY0gVFnsKUyjfNWF1UQsCSjw93Sj5jSbiO8RPfdw=="
+    },
+    "node_modules/@airgap/beacon-utils/node_modules/libsodium-wrappers": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.9.tgz",
+      "integrity": "sha512-9HaAeBGk1nKTRFRHkt7nzxqCvnkWTjn1pdjKgcUnZxj0FyOP4CnhgFhMdrFfgNsukijBGyBLpP2m2uKT1vuWhQ==",
+      "dependencies": {
+        "libsodium": "^0.7.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -495,29 +626,135 @@
       "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg=="
     },
     "node_modules/@taquito/beacon-wallet": {
-      "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/@taquito/beacon-wallet/-/beacon-wallet-12.0.3.tgz",
-      "integrity": "sha512-cu3CWPW5h1pBY71opsroU+Nwq9rApMNZH3VfGlz1xPkOFtF4uuo7baVmc7y1NamEKdNfc8hM/XH9EYDRHCIlcg==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@taquito/beacon-wallet/-/beacon-wallet-13.0.1.tgz",
+      "integrity": "sha512-HBJoIwVqV4UorqCzLYaKT1QSA2OoujhBidENYhPE+Km/w7ArGLcPCTrhNvtfViw8xyhG63/hlFztLC3mm0M8iA==",
       "dependencies": {
-        "@airgap/beacon-sdk": "^2.3.12",
-        "@taquito/taquito": "^12.0.3"
+        "@airgap/beacon-dapp": "^3.1.3",
+        "@taquito/taquito": "^13.0.1",
+        "libsodium-wrappers": "0.7.9"
       },
       "engines": {
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@taquito/beacon-wallet/node_modules/@airgap/beacon-sdk": {
-      "version": "2.3.12",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-sdk/-/beacon-sdk-2.3.12.tgz",
-      "integrity": "sha512-SZIaPiJjYHq5FIbpldHcPuMJxntjNfi+Iyni1apODh6hdgsJK8wRkveBd/b9LvmRSFnAENP3Zrbtayegfch8Ow==",
+    "node_modules/@taquito/beacon-wallet/node_modules/@taquito/http-utils": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-13.0.1.tgz",
+      "integrity": "sha512-eHzd0HSL3qX6bOOSaQClm+0XmpbSNcJP69uzaBJwfXo7ntQR1bUfGLn6+1Hgsk/lJ0JxakD2PDA4aaeajHvyPw==",
       "dependencies": {
-        "@types/chrome": "0.0.115",
-        "@types/libsodium-wrappers": "0.7.7",
-        "axios": "0.21.1",
-        "bignumber.js": "9.0.0",
-        "bs58check": "2.1.2",
-        "libsodium-wrappers": "0.7.8",
-        "qrcode-generator": "1.4.4"
+        "axios": "^0.26.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@taquito/beacon-wallet/node_modules/@taquito/local-forging": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@taquito/local-forging/-/local-forging-13.0.1.tgz",
+      "integrity": "sha512-2n1ryUzHBIOHiQYRO7ELQaurjoNhJ3KUUcX0dAnFs3xVxUBugHgDPot+T+1rNZDdLVhTS6mmK796xrWDGnO6xw==",
+      "dependencies": {
+        "@taquito/utils": "^13.0.1",
+        "bignumber.js": "^9.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@taquito/beacon-wallet/node_modules/@taquito/michel-codec": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-13.0.1.tgz",
+      "integrity": "sha512-A9MxhDMdTTK31ty5Ke2wg4wkt7F/Y++tD8wq9YIFJzxt+MkpWX5b2i1f7yHXPsK/81YiGAi/LDamLtLCekY1LA==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@taquito/beacon-wallet/node_modules/@taquito/michelson-encoder": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-13.0.1.tgz",
+      "integrity": "sha512-U80vswMHlEDQUjvARZScIKrSZkIjxdYtDLvHu4oRZ9wTqTXSlj+t64G5QmZwTEJRQkbzfhsOOr6vL40ztL0tzw==",
+      "dependencies": {
+        "@taquito/rpc": "^13.0.1",
+        "@taquito/utils": "^13.0.1",
+        "bignumber.js": "^9.0.2",
+        "fast-json-stable-stringify": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@taquito/beacon-wallet/node_modules/@taquito/rpc": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-13.0.1.tgz",
+      "integrity": "sha512-f2Z0qzHB1ERLU5kewmXh3rAD84qIYthSjmAo04sWFbuaMgGW1HxMJKJ/EtL4s4VgoDUwahSwfATmVzmKg57BSw==",
+      "dependencies": {
+        "@taquito/http-utils": "^13.0.1",
+        "@taquito/utils": "^13.0.1",
+        "bignumber.js": "^9.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@taquito/beacon-wallet/node_modules/@taquito/taquito": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-13.0.1.tgz",
+      "integrity": "sha512-xNtcwKsOCHSkURO9G2VhKSeI9q0qh5/OkVuYe6KM0Fo40FthXNqq205I/FTJzu5E1Q73J7cFqA7FHqUrv276gw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@taquito/http-utils": "^13.0.1",
+        "@taquito/local-forging": "^13.0.1",
+        "@taquito/michel-codec": "^13.0.1",
+        "@taquito/michelson-encoder": "^13.0.1",
+        "@taquito/rpc": "^13.0.1",
+        "@taquito/utils": "^13.0.1",
+        "bignumber.js": "^9.0.2",
+        "rxjs": "^6.6.3"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@taquito/beacon-wallet/node_modules/@taquito/utils": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-13.0.1.tgz",
+      "integrity": "sha512-uRtsl4EATlVJ1UnNUiAEoibFFyexGLDLz02CBHoBrcWjqrZdj3AxA+TO63E2kWn/JmT2FM0Sqaqbm555lj4tow==",
+      "dependencies": {
+        "@stablelib/blake2b": "^1.0.1",
+        "@stablelib/ed25519": "^1.0.2",
+        "@types/bs58check": "^2.1.0",
+        "blakejs": "^1.2.1",
+        "bs58check": "^2.1.2",
+        "buffer": "^6.0.3",
+        "elliptic": "^6.5.4",
+        "typedarray-to-buffer": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@taquito/beacon-wallet/node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
+    "node_modules/@taquito/beacon-wallet/node_modules/bignumber.js": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
+      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@taquito/beacon-wallet/node_modules/libsodium-wrappers": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.9.tgz",
+      "integrity": "sha512-9HaAeBGk1nKTRFRHkt7nzxqCvnkWTjn1pdjKgcUnZxj0FyOP4CnhgFhMdrFfgNsukijBGyBLpP2m2uKT1vuWhQ==",
+      "dependencies": {
+        "libsodium": "^0.7.0"
       }
     },
     "node_modules/@taquito/http-utils": {
@@ -812,25 +1049,6 @@
         "node": "*"
       }
     },
-    "node_modules/@taquito/taquito/node_modules/follow-redirects": {
-      "version": "1.14.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@taquito/tzip16": {
       "version": "12.0.3",
       "resolved": "https://registry.npmjs.org/@taquito/tzip16/-/tzip16-12.0.3.tgz",
@@ -900,25 +1118,6 @@
       "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/@taquito/tzip16/node_modules/follow-redirects": {
-      "version": "1.14.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
       }
     },
     "node_modules/@taquito/utils": {
@@ -1731,9 +1930,9 @@
       "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
     },
     "node_modules/blakejs": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.1.tgz",
-      "integrity": "sha512-bLG6PHOCZJKNshTjGRBvET0vTciwQE6zFKOKKXPDJfwFBd4Ac0yBfPZqcGvGJap50l7ktvlpFqc2jGVaUgbJgg=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
     },
     "node_modules/blob-polyfill": {
       "version": "5.0.20210201",
@@ -3809,9 +4008,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
-      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
       "funding": [
         {
           "type": "individual",
@@ -12663,6 +12862,45 @@
     }
   },
   "dependencies": {
+    "@airgap/beacon-core": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-core/-/beacon-core-3.1.3.tgz",
+      "integrity": "sha512-AU8VCS5DeK4aXLIeiW6ie377gwEXkuxDS+UiH60yID5VYGc4YgD+kTrjh0BawCJbQumj/+H5OphGl6n+XJX6Ww==",
+      "requires": {
+        "@airgap/beacon-types": "^3.1.3",
+        "@airgap/beacon-utils": "^3.1.2",
+        "@types/libsodium-wrappers": "0.7.9",
+        "bs58check": "2.1.2",
+        "libsodium-wrappers": "0.7.9"
+      },
+      "dependencies": {
+        "@types/libsodium-wrappers": {
+          "version": "0.7.9",
+          "resolved": "https://registry.npmjs.org/@types/libsodium-wrappers/-/libsodium-wrappers-0.7.9.tgz",
+          "integrity": "sha512-LisgKLlYQk19baQwjkBZZXdJL0KbeTpdEnrAfz5hQACbklCY0gVFnsKUyjfNWF1UQsCSjw93Sj5jSbiO8RPfdw=="
+        },
+        "libsodium-wrappers": {
+          "version": "0.7.9",
+          "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.9.tgz",
+          "integrity": "sha512-9HaAeBGk1nKTRFRHkt7nzxqCvnkWTjn1pdjKgcUnZxj0FyOP4CnhgFhMdrFfgNsukijBGyBLpP2m2uKT1vuWhQ==",
+          "requires": {
+            "libsodium": "^0.7.0"
+          }
+        }
+      }
+    },
+    "@airgap/beacon-dapp": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-dapp/-/beacon-dapp-3.1.3.tgz",
+      "integrity": "sha512-iyXZK9VTL/YRxY2JQDJSWT1+wHuVJ28+JL5ArmQRoOlhEUTVSBKdtSYX34ojOSsqQEGUuW9MTLIM/0vrWQYR3Q==",
+      "requires": {
+        "@airgap/beacon-core": "^3.1.3",
+        "@airgap/beacon-transport-matrix": "^3.1.3",
+        "@airgap/beacon-transport-postmessage": "^3.1.3",
+        "@airgap/beacon-ui": "^3.1.3",
+        "qrcode-generator": "1.4.4"
+      }
+    },
     "@airgap/beacon-sdk": {
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/@airgap/beacon-sdk/-/beacon-sdk-2.3.9.tgz",
@@ -12675,6 +12913,108 @@
         "bs58check": "2.1.2",
         "libsodium-wrappers": "0.7.8",
         "qrcode-generator": "1.4.4"
+      }
+    },
+    "@airgap/beacon-transport-matrix": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-transport-matrix/-/beacon-transport-matrix-3.1.3.tgz",
+      "integrity": "sha512-pbehQ4IfMU4lR5mkLTYU5QorrbMvxvOXiWisqziIG0XCAj7FwiZVx30ljT22vWiqygGSTrVGGTwUuhbqX6aKtA==",
+      "requires": {
+        "@airgap/beacon-core": "^3.1.3",
+        "@airgap/beacon-utils": "^3.1.2",
+        "axios": "0.24.0"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.24.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+          "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+          "requires": {
+            "follow-redirects": "^1.14.4"
+          }
+        }
+      }
+    },
+    "@airgap/beacon-transport-postmessage": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-transport-postmessage/-/beacon-transport-postmessage-3.1.3.tgz",
+      "integrity": "sha512-Cv2Bjpvex5XZ1n9GVfi4iPA4l1hz8LcvBSec6iCEI0Ejjt8bYTPqJESZyxh5Z5A4VXG/gSSS2i1WhzzoyorbfA==",
+      "requires": {
+        "@airgap/beacon-core": "^3.1.3",
+        "@airgap/beacon-types": "^3.1.3",
+        "@airgap/beacon-utils": "^3.1.2",
+        "@types/libsodium-wrappers": "0.7.9",
+        "libsodium-wrappers": "0.7.9"
+      },
+      "dependencies": {
+        "@types/libsodium-wrappers": {
+          "version": "0.7.9",
+          "resolved": "https://registry.npmjs.org/@types/libsodium-wrappers/-/libsodium-wrappers-0.7.9.tgz",
+          "integrity": "sha512-LisgKLlYQk19baQwjkBZZXdJL0KbeTpdEnrAfz5hQACbklCY0gVFnsKUyjfNWF1UQsCSjw93Sj5jSbiO8RPfdw=="
+        },
+        "libsodium-wrappers": {
+          "version": "0.7.9",
+          "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.9.tgz",
+          "integrity": "sha512-9HaAeBGk1nKTRFRHkt7nzxqCvnkWTjn1pdjKgcUnZxj0FyOP4CnhgFhMdrFfgNsukijBGyBLpP2m2uKT1vuWhQ==",
+          "requires": {
+            "libsodium": "^0.7.0"
+          }
+        }
+      }
+    },
+    "@airgap/beacon-types": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-types/-/beacon-types-3.1.3.tgz",
+      "integrity": "sha512-UCsba/Dut6cUrYIe2bnLlCOGsCyQOD/A4gQGdCuviLfqomMQv5m/XoJTtl9jKOlOIm2ytvyl8Z/zrNhK7SZMmA==",
+      "requires": {
+        "@types/chrome": "0.0.163"
+      },
+      "dependencies": {
+        "@types/chrome": {
+          "version": "0.0.163",
+          "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.163.tgz",
+          "integrity": "sha512-g+3E2tg/ukFsEgH+tB3a/b+J1VSvq/8gh2Jwih9eq+T3Idrz7ngj97u+/ya58Bfei2TQtPlRivj1FsCaSnukDA==",
+          "requires": {
+            "@types/filesystem": "*",
+            "@types/har-format": "*"
+          }
+        }
+      }
+    },
+    "@airgap/beacon-ui": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-ui/-/beacon-ui-3.1.3.tgz",
+      "integrity": "sha512-H6L9lynsn/JsjrKEBrN5lYr1S/d8l3aY48lciNfxJALOR1mOjVBn+tepKP/tVZPansvvf27/8yKwUTMVnp4Qwg==",
+      "requires": {
+        "@airgap/beacon-core": "^3.1.3",
+        "@airgap/beacon-transport-postmessage": "^3.1.3",
+        "@airgap/beacon-types": "^3.1.3",
+        "@airgap/beacon-utils": "^3.1.2"
+      }
+    },
+    "@airgap/beacon-utils": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-utils/-/beacon-utils-3.1.2.tgz",
+      "integrity": "sha512-kaDFDSes54Zn/cc6Pvk9BfrrvrLwqTPNuEg15uzAQkDRsZ8e/t7SZ7KTNytw2OJPI0qG792zvd5uJwSG8a0Jdg==",
+      "requires": {
+        "@types/libsodium-wrappers": "0.7.9",
+        "bs58check": "2.1.2",
+        "libsodium-wrappers": "0.7.9"
+      },
+      "dependencies": {
+        "@types/libsodium-wrappers": {
+          "version": "0.7.9",
+          "resolved": "https://registry.npmjs.org/@types/libsodium-wrappers/-/libsodium-wrappers-0.7.9.tgz",
+          "integrity": "sha512-LisgKLlYQk19baQwjkBZZXdJL0KbeTpdEnrAfz5hQACbklCY0gVFnsKUyjfNWF1UQsCSjw93Sj5jSbiO8RPfdw=="
+        },
+        "libsodium-wrappers": {
+          "version": "0.7.9",
+          "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.9.tgz",
+          "integrity": "sha512-9HaAeBGk1nKTRFRHkt7nzxqCvnkWTjn1pdjKgcUnZxj0FyOP4CnhgFhMdrFfgNsukijBGyBLpP2m2uKT1vuWhQ==",
+          "requires": {
+            "libsodium": "^0.7.0"
+          }
+        }
       }
     },
     "@babel/code-frame": {
@@ -13028,26 +13368,107 @@
       "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg=="
     },
     "@taquito/beacon-wallet": {
-      "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/@taquito/beacon-wallet/-/beacon-wallet-12.0.3.tgz",
-      "integrity": "sha512-cu3CWPW5h1pBY71opsroU+Nwq9rApMNZH3VfGlz1xPkOFtF4uuo7baVmc7y1NamEKdNfc8hM/XH9EYDRHCIlcg==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@taquito/beacon-wallet/-/beacon-wallet-13.0.1.tgz",
+      "integrity": "sha512-HBJoIwVqV4UorqCzLYaKT1QSA2OoujhBidENYhPE+Km/w7ArGLcPCTrhNvtfViw8xyhG63/hlFztLC3mm0M8iA==",
       "requires": {
-        "@airgap/beacon-sdk": "^2.3.12",
-        "@taquito/taquito": "^12.0.3"
+        "@airgap/beacon-dapp": "^3.1.3",
+        "@taquito/taquito": "^13.0.1",
+        "libsodium-wrappers": "0.7.9"
       },
       "dependencies": {
-        "@airgap/beacon-sdk": {
-          "version": "2.3.12",
-          "resolved": "https://registry.npmjs.org/@airgap/beacon-sdk/-/beacon-sdk-2.3.12.tgz",
-          "integrity": "sha512-SZIaPiJjYHq5FIbpldHcPuMJxntjNfi+Iyni1apODh6hdgsJK8wRkveBd/b9LvmRSFnAENP3Zrbtayegfch8Ow==",
+        "@taquito/http-utils": {
+          "version": "13.0.1",
+          "resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-13.0.1.tgz",
+          "integrity": "sha512-eHzd0HSL3qX6bOOSaQClm+0XmpbSNcJP69uzaBJwfXo7ntQR1bUfGLn6+1Hgsk/lJ0JxakD2PDA4aaeajHvyPw==",
           "requires": {
-            "@types/chrome": "0.0.115",
-            "@types/libsodium-wrappers": "0.7.7",
-            "axios": "0.21.1",
-            "bignumber.js": "9.0.0",
-            "bs58check": "2.1.2",
-            "libsodium-wrappers": "0.7.8",
-            "qrcode-generator": "1.4.4"
+            "axios": "^0.26.0"
+          }
+        },
+        "@taquito/local-forging": {
+          "version": "13.0.1",
+          "resolved": "https://registry.npmjs.org/@taquito/local-forging/-/local-forging-13.0.1.tgz",
+          "integrity": "sha512-2n1ryUzHBIOHiQYRO7ELQaurjoNhJ3KUUcX0dAnFs3xVxUBugHgDPot+T+1rNZDdLVhTS6mmK796xrWDGnO6xw==",
+          "requires": {
+            "@taquito/utils": "^13.0.1",
+            "bignumber.js": "^9.0.2"
+          }
+        },
+        "@taquito/michel-codec": {
+          "version": "13.0.1",
+          "resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-13.0.1.tgz",
+          "integrity": "sha512-A9MxhDMdTTK31ty5Ke2wg4wkt7F/Y++tD8wq9YIFJzxt+MkpWX5b2i1f7yHXPsK/81YiGAi/LDamLtLCekY1LA=="
+        },
+        "@taquito/michelson-encoder": {
+          "version": "13.0.1",
+          "resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-13.0.1.tgz",
+          "integrity": "sha512-U80vswMHlEDQUjvARZScIKrSZkIjxdYtDLvHu4oRZ9wTqTXSlj+t64G5QmZwTEJRQkbzfhsOOr6vL40ztL0tzw==",
+          "requires": {
+            "@taquito/rpc": "^13.0.1",
+            "@taquito/utils": "^13.0.1",
+            "bignumber.js": "^9.0.2",
+            "fast-json-stable-stringify": "^2.1.0"
+          }
+        },
+        "@taquito/rpc": {
+          "version": "13.0.1",
+          "resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-13.0.1.tgz",
+          "integrity": "sha512-f2Z0qzHB1ERLU5kewmXh3rAD84qIYthSjmAo04sWFbuaMgGW1HxMJKJ/EtL4s4VgoDUwahSwfATmVzmKg57BSw==",
+          "requires": {
+            "@taquito/http-utils": "^13.0.1",
+            "@taquito/utils": "^13.0.1",
+            "bignumber.js": "^9.0.2"
+          }
+        },
+        "@taquito/taquito": {
+          "version": "13.0.1",
+          "resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-13.0.1.tgz",
+          "integrity": "sha512-xNtcwKsOCHSkURO9G2VhKSeI9q0qh5/OkVuYe6KM0Fo40FthXNqq205I/FTJzu5E1Q73J7cFqA7FHqUrv276gw==",
+          "requires": {
+            "@taquito/http-utils": "^13.0.1",
+            "@taquito/local-forging": "^13.0.1",
+            "@taquito/michel-codec": "^13.0.1",
+            "@taquito/michelson-encoder": "^13.0.1",
+            "@taquito/rpc": "^13.0.1",
+            "@taquito/utils": "^13.0.1",
+            "bignumber.js": "^9.0.2",
+            "rxjs": "^6.6.3"
+          }
+        },
+        "@taquito/utils": {
+          "version": "13.0.1",
+          "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-13.0.1.tgz",
+          "integrity": "sha512-uRtsl4EATlVJ1UnNUiAEoibFFyexGLDLz02CBHoBrcWjqrZdj3AxA+TO63E2kWn/JmT2FM0Sqaqbm555lj4tow==",
+          "requires": {
+            "@stablelib/blake2b": "^1.0.1",
+            "@stablelib/ed25519": "^1.0.2",
+            "@types/bs58check": "^2.1.0",
+            "blakejs": "^1.2.1",
+            "bs58check": "^2.1.2",
+            "buffer": "^6.0.3",
+            "elliptic": "^6.5.4",
+            "typedarray-to-buffer": "^4.0.0"
+          }
+        },
+        "axios": {
+          "version": "0.26.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+          "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+          "requires": {
+            "follow-redirects": "^1.14.8"
+          }
+        },
+        "bignumber.js": {
+          "version": "9.0.2",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
+          "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw=="
+        },
+        "libsodium-wrappers": {
+          "version": "0.7.9",
+          "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.9.tgz",
+          "integrity": "sha512-9HaAeBGk1nKTRFRHkt7nzxqCvnkWTjn1pdjKgcUnZxj0FyOP4CnhgFhMdrFfgNsukijBGyBLpP2m2uKT1vuWhQ==",
+          "requires": {
+            "libsodium": "^0.7.0"
           }
         }
       }
@@ -13280,11 +13701,6 @@
           "version": "9.0.2",
           "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
           "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw=="
-        },
-        "follow-redirects": {
-          "version": "1.14.9",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-          "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
         }
       }
     },
@@ -13343,11 +13759,6 @@
           "version": "9.0.2",
           "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
           "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw=="
-        },
-        "follow-redirects": {
-          "version": "1.14.9",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-          "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
         }
       }
     },
@@ -13987,9 +14398,9 @@
       }
     },
     "blakejs": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.1.tgz",
-      "integrity": "sha512-bLG6PHOCZJKNshTjGRBvET0vTciwQE6zFKOKKXPDJfwFBd4Ac0yBfPZqcGvGJap50l7ktvlpFqc2jGVaUgbJgg=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
     },
     "blob-polyfill": {
       "version": "5.0.20210201",
@@ -15664,9 +16075,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
-      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg=="
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
     },
     "form-data": {
       "version": "4.0.0",

--- a/dapp/package.json
+++ b/dapp/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@metamask/detect-provider": "^1.2.0",
     "@spruceid/tzprofiles": "^1.0.1",
-    "@taquito/beacon-wallet": "^12.0.3",
+    "@taquito/beacon-wallet": "^13.0.1",
     "@taquito/local-forging": "^12.0.3",
     "@taquito/taquito": "^12.0.3",
     "@taquito/tzip16": "^12.0.3",

--- a/dapp/src/enums/NetworkType.ts
+++ b/dapp/src/enums/NetworkType.ts
@@ -1,7 +1,6 @@
 enum NetworkType {
   MAINNET = 'mainnet',
-  HANGZHOUNET = 'hangzhounet',
-  // ITHICANET = 'ithicanet',
+  GHOSTNET = 'ghostnet',
   CUSTOM = 'custom',
 }
 

--- a/dapp/src/routes/Connect/Connect.svelte
+++ b/dapp/src/routes/Connect/Connect.svelte
@@ -43,7 +43,9 @@
     <div class="text-2xl font-bold body mb-6 pt-4">
       Choose network and connect
     </div>
-    <div class="flex items-center relative max-w-60 w-full mx-auto cursor-pointer">
+    <div
+      class="flex items-center relative max-w-60 w-full mx-auto cursor-pointer"
+    >
       <Select
         name="network"
         id="network"
@@ -51,8 +53,7 @@
         onChange={setSelectedNetwork}
       >
         <Option value="mainnet" text="mainnet" selected />
-        <Option value="hangzhounet" text="hangzhounet" />
-        <!-- Option value="ithicanet" text="ithicanet" -->
+        <Option value="ghostnet" text="ghostnet" />
         <Option value="custom" text="localhost" />
       </Select>
       <div

--- a/dapp/src/routes/Search/Search.svelte
+++ b/dapp/src/routes/Search/Search.svelte
@@ -58,7 +58,9 @@
 
 <svelte:window on:keydown={handleKeydown} />
 
-<BasePage class="flex flex-col items-center justify-center mx-4 flex-1 pt-18 sm:pt-22 md:pt-34">
+<BasePage
+  class="flex flex-col items-center justify-center mx-4 flex-1 pt-18 sm:pt-22 md:pt-34"
+>
   <div class="search-container dropshadow-default fade-in">
     <div class="mb-4 text-2xl text-left font-bold body">
       Tezos Profiles Explorer
@@ -80,8 +82,7 @@
             class="w-full"
           >
             <Option value="mainnet" text="mainnet" selected />
-            <Option value="hangzhounet" text="hangzhounet" />
-            <!-- Option value="ithicanet" text="ithicanet" / -->
+            <Option value="ghostnet" text="ghostnet" />
             <Option value="custom" text="localhost" />
           </Select>
           <div

--- a/dapp/src/store.ts
+++ b/dapp/src/store.ts
@@ -409,7 +409,17 @@ network.subscribe((network) => {
     networkStrTemp = network;
     strNetwork = network;
 
-    urlNode = `https://${network}.api.tez.ie/`;
+    switch(network ){
+      case "mainnet":
+        urlNode = `https://${network}.api.tez.ie`;
+        break;
+      case 'ghostnet':
+        urlNode = 'https://ghostnet.ecadinfra.com';
+        break;
+      default:
+        urlNode = `https://${network}.api.tez.ie`;
+        break;
+    }
     nodeUrl.set(urlNode);
 
     tzktBaseTemp = `https://api.${networkStrTemp}.tzkt.io`;


### PR DESCRIPTION
## What?

Made the necessary changes to enable ghostnet connection. Updated the version of @taquito/beacon-wallet to 13.0.1 to support ghostnet. 

## Author

This PR is offered by the _GaiaX GAIA-X 4 Future Mobility_ community. Read more about the project [here](https://www.dlr.de/content/de/artikel/news/2022/01/20220125_datenzentrierte-loesungen-fuer-die-mobilitaet-der-zukunft.html).

## Misc.
If you get `Cannot read properties of undefined (reading 'rc')` in your browser's console when you run _dapp,_ then:

1. In your dapp/node_modules, locate @taquito/beacon-wallet and delete the node_modules folder inside of it.
2. Run `npm install` inside the @taquito/beacon-wallet.

This should fix the issue.